### PR TITLE
Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# this project
+*.pdf
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/harris/core/problema_2.26.py
+++ b/harris/core/problema_2.26.py
@@ -9,9 +9,11 @@ def plates_theorical(A, B, C, u):
     Parameters
     ----------
     A : float
-        peak widening by preferred paths
+        Eddy-diffusion parameter, related to channeling through a non-ideal
+        packing. Dimension L
     B :float
-        solute diffusion in the mobile phase
+         diffusion coefficient of the eluting particles in the longitudinal
+         direction, resulting in dispersion. Dimension L^2 / T
     C : float
         solute diffusion in the stationary phase
     u : float

--- a/harris/core/problema_2.26.py
+++ b/harris/core/problema_2.26.py
@@ -3,7 +3,8 @@ import matplotlib.pyplot as plt
 
 
 def plates_theorical(A, B, C, u):
-    """Calculates the height of the theoretical plates present in a chromatographic column
+    """Calculates the height of the theoretical plates present in a
+    chromatographic column
 
     Parameters
     ----------
@@ -36,6 +37,6 @@ if __name__ == '__main__':
     # save plot to file
     plt.savefig("Van Deemter's equation.pdf")
 
- # display plot on screen
+    # display plot on screen
     plt.show()
     print(H)

--- a/harris/core/problema_2.26.py
+++ b/harris/core/problema_2.26.py
@@ -10,19 +10,21 @@ def plates_theorical(A, B, C, u):
     ----------
     A : float
         Eddy-diffusion parameter, related to channeling through a non-ideal
-        packing. Dimension L
+        packing. Dimension L.
     B :float
-         diffusion coefficient of the eluting particles in the longitudinal
-         direction, resulting in dispersion. Dimension L^2 / T
+         Diffusion coefficient of the eluting particles in the longitudinal
+         direction, resulting in dispersion. Dimension L^2 / T.
     C : float
-        solute diffusion in the stationary phase
-    u : float
-        carrier gas speed
+        Resistance to mass transfer coefficient of the analyte between mobile
+        and stationary phase. Dimension T.
+    u : array
+        Linear velocity. Dimension L / T.
 
     Returns
     -------
     float
-        equivalent height of a theoretical plate.
+        equivalent height of a theoretical plate, a measure of the resolving
+        power of the column. Dimension L.
     """
     H = A + (B / u) + (C * u)
     return(H)

--- a/harris/core/problema_2.26.py
+++ b/harris/core/problema_2.26.py
@@ -28,15 +28,17 @@ def plates_theorical(A, B, C, u):
 
 if __name__ == '__main__':
     H = plates_theorical(1.65, 25.8, 0.0236, np.arange(4, 102, 2))
+
     plt.figure(1, figsize=(6, 4))
     plt.style.use('seaborn-whitegrid')
     plt.plot(H, np.arange(4, 102, 2))
-    plt.xlabel('Height of theoretical plates(mm)')
-    plt.ylabel('Carrier gas speed(mL/min)')
+    plt.xlabel('Height of theoretical plates / (mm)')
+    plt.ylabel('Carrier gas speed / (mL/min)')
+    plt.tight_layout()  # avoids cutting labels depending on style
 
     # save plot to file
     plt.savefig("Van Deemter's equation.pdf")
 
     # display plot on screen
     plt.show()
-    print(H)
+    # print(H)  # activate for values


### PR DESCRIPTION
Added the following corrections:

- pdf files should be in gitignore and manually added only when needed. See [here](https://tex.stackexchange.com/a/239481/145013) and [here](https://stackoverflow.com/questions/17772048/when-should-pdf-files-be-tracked-in-a-git-repository-and-when-not). The same is true for Jupyter Notebooks as seen [here](https://nextjournal.com/schmudde/how-to-version-control-jupyter).
-  if you want the example plot to be seen by others, embed it in a md file (I will do this in a future PR). I think it would be nice a md file for each chapter with the question and some info.
- please be aware of linter messages (long lines and other PEP8 warnings)
- I fixed the definitions for A, B and C based on [here](https://en.wikipedia.org/wiki/Van_Deemter_equation). Also, units or dimensions should be specified. I prefer the [dimension](https://en.wikipedia.org/wiki/Dimensional_analysis#Mathematical_formulation).
- `u` is not a float, it is an array.
- use [matplotlib's tight layout](https://matplotlib.org/tutorials/intermediate/tight_layout_guide.html) to avoid label cutting. I tested other styles and some of them cuts the labels.
- I commented the `print(H)` line. Was it only a test or do you really wanted it to be displayed? Maybe an option to export the values to a csv file would be more suitable for those who want the data.
- Symbols for units are treated as mathematical entities. The entries in a table or axes of a graph are all simply numbers. So the axes should be labelled with the unit name divided by the unit. Please see [this](https://www.bipm.org/en/publications/si-brochure/section5-3.html) and the following links (questions and answers): [link 1](https://physics.stackexchange.com/a/59981/176460), [link 2](https://academia.stackexchange.com/questions/18357/are-there-any-guidelines-for-labeling-axes-in-plots-graphs)